### PR TITLE
ssh: Use a common default ssh username for newly created instances

### DIFF
--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -77,6 +77,7 @@ _multipass_complete()
             ;;
             "--cloud-init")
                 _filedir
+                return
             ;;
         esac
     else
@@ -107,9 +108,19 @@ _multipass_complete()
                 if [ ${source_set} == 0 ] ; then
                     if [[ ${prev} != -* ]] || ([[ ${prev} == -* ]] && [[ ${prev} == *=* ]]); then
                         _filedir -d
+                        return
                     fi
                 elif [ ${source_set} == 1 ] && [[ ${prev} != -* ]]; then
                     _multipass_instances
+                fi
+            ;;
+            "copy-files")
+                _multipass_instances "RUNNING"
+
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                if [[ "${#COMPREPLY[@]}" == "0" ]]; then
+                    _filedir
+                    return
                 fi
             ;;
             "help")

--- a/completions/bash/multipass
+++ b/completions/bash/multipass
@@ -75,7 +75,7 @@ _multipass_complete()
             "--format"|"-f")
                 opts="table json csv yaml"
             ;;
-            "--cloud-init")
+            "--cloud-init"|"--image")
                 _filedir
                 return
             ;;

--- a/include/multipass/query.h
+++ b/include/multipass/query.h
@@ -27,10 +27,18 @@ namespace multipass
 class Query
 {
 public:
+    enum Type
+    {
+        SimpleStreams,
+        LocalFile,
+        HttpDownload
+    };
+
     std::string name;
     std::string release;
     bool persistent;
     std::string remote_name;
+    Type query_type;
 };
 }
 #endif // MULTIPASS_QUERY_H

--- a/include/multipass/ssh/scp_client.h
+++ b/include/multipass/ssh/scp_client.h
@@ -33,7 +33,7 @@ using SSHSessionUPtr = std::unique_ptr<SSHSession>;
 class SCPClient
 {
 public:
-    SCPClient(const std::string& host, int port, const std::string& priv_key_blob);
+    SCPClient(const std::string& host, int port, const std::string& username, const std::string& priv_key_blob);
     SCPClient(SSHSessionUPtr ssh_session);
 
     void push_file(const std::string& source_path, const std::string& destination_path);

--- a/include/multipass/ssh/ssh_client.h
+++ b/include/multipass/ssh/ssh_client.h
@@ -36,7 +36,7 @@ class SSHClient
 public:
     using ChannelUPtr = std::unique_ptr<ssh_channel_struct, void (*)(ssh_channel)>;
 
-    SSHClient(const std::string& host, int port, const std::string& priv_key_blob);
+    SSHClient(const std::string& host, int port, const std::string& username, const std::string& priv_key_blob);
     SSHClient(SSHSessionUPtr ssh_session, Console::UPtr console = nullptr);
 
     int exec(const std::vector<std::string>& args);

--- a/include/multipass/ssh/ssh_session.h
+++ b/include/multipass/ssh/ssh_session.h
@@ -34,7 +34,7 @@ class SSHSession
 {
 public:
     SSHSession(const std::string& host, int port);
-    SSHSession(const std::string& host, int port, const SSHKeyProvider& key_provider);
+    SSHSession(const std::string& host, int port, const std::string& ssh_username, const SSHKeyProvider& key_provider);
 
     SSHProcess exec(const std::string& cmd);
 
@@ -43,7 +43,7 @@ public:
 private:
     operator ssh_session() const;
 
-    SSHSession(const std::string& host, int port, const SSHKeyProvider* key_provider);
+    SSHSession(const std::string& host, int port, const std::string& ssh_username, const SSHKeyProvider* key_provider);
     std::unique_ptr<ssh_session_struct, void(*)(ssh_session)> session;
 
     friend class SCPClient;

--- a/include/multipass/virtual_machine.h
+++ b/include/multipass/virtual_machine.h
@@ -50,6 +50,7 @@ public:
     virtual State current_state() = 0;
     virtual int ssh_port() = 0;
     virtual std::string ssh_hostname() = 0;
+    virtual std::string ssh_username() = 0;
     virtual std::string ipv4() = 0;
     virtual std::string ipv6() = 0;
     virtual void wait_until_ssh_up(std::chrono::milliseconds timeout) = 0;

--- a/include/multipass/virtual_machine_description.h
+++ b/include/multipass/virtual_machine_description.h
@@ -36,6 +36,7 @@ public:
     std::string disk_space;
     std::string vm_name;
     std::string mac_addr;
+    std::string ssh_username;
     VMImage image;
     Path cloud_init_iso;
     const SSHKeyProvider& key_provider;

--- a/include/multipass/vm_image.h
+++ b/include/multipass/vm_image.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical, Ltd.
+ * Copyright (C) 2017-2018 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,6 +33,8 @@ public:
     Path kernel_path;
     Path initrd_path;
     std::string id;
+    std::string original_release;
+    std::string current_release;
     std::vector<std::string> aliases;
 };
 }

--- a/src/client/cmd/copy_files.cpp
+++ b/src/client/cmd/copy_files.cpp
@@ -56,6 +56,7 @@ mp::ReturnCode cmd::CopyFiles::run(mp::ArgParser* parser)
 
             auto host = ssh_info.host();
             auto port = ssh_info.port();
+            auto username = ssh_info.username();
             auto priv_key_blob = ssh_info.priv_key_base64();
 
             auto destination_path{destination.second};
@@ -71,7 +72,7 @@ mp::ReturnCode cmd::CopyFiles::run(mp::ArgParser* parser)
 
             try
             {
-                mp::SCPClient scp_client{host, port, priv_key_blob};
+                mp::SCPClient scp_client{host, port, username, priv_key_blob};
                 if (!destination.first.empty())
                     scp_client.push_file(source.second, destination_path);
                 else

--- a/src/client/cmd/exec.cpp
+++ b/src/client/cmd/exec.cpp
@@ -73,11 +73,12 @@ mp::ReturnCode cmd::Exec::exec_success(const mp::SSHInfoReply& reply, const std:
     auto ssh_info = reply.ssh_info().begin()->second;
     auto host = ssh_info.host();
     auto port = ssh_info.port();
+    auto username = ssh_info.username();
     auto priv_key_blob = ssh_info.priv_key_base64();
 
     try
     {
-        mp::SSHClient ssh_client{host, port, priv_key_blob};
+        mp::SSHClient ssh_client{host, port, username, priv_key_blob};
         return static_cast<mp::ReturnCode>(ssh_client.exec(args));
     }
     catch (const std::exception& e)

--- a/src/client/cmd/find.cpp
+++ b/src/client/cmd/find.cpp
@@ -125,11 +125,12 @@ QString cmd::Find::description() const
 mp::ParseCode cmd::Find::parse_args(mp::ArgParser* parser)
 {
     parser->addPositionalArgument("string",
-                                  "An optional value to search for in [<type:>]<string> format, where "
-                                  "<type> can be either ‘release’ or ‘daily’. If <type> is omitted, "
-                                  "it defaults to ‘release’. <string> can be a partial image hash or an "
-                                  "ubuntu release version, codename or alias",
-                                  "[<string>]");
+                                  "An optional value to search for in [<remote:>]<string> format, where "
+                                  "<remote> can be either ‘release’ or ‘daily’. If <remote> is omitted, "
+                                  "it will search ‘release‘ first, and if no matches are found, it will "
+                                  "then search ‘daily‘. <string> can be a partial image hash or an "
+                                  "Ubuntu release version, codename or alias.",
+                                  "[<remote:>][<string>]");
 
     auto status = parser->commandParse(this);
 

--- a/src/client/cmd/launch.cpp
+++ b/src/client/cmd/launch.cpp
@@ -128,7 +128,9 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
                                  "1024"); // In MB's
     QCommandLineOption nameOption({"n", "name"}, "Name for the instance", "name");
     QCommandLineOption cloudInitOption("cloud-init", "Path to a user-data cloud-init configuration", "file");
-    parser->addOptions({cpusOption, diskOption, memOption, nameOption, cloudInitOption});
+    QCommandLineOption imageOption("image", "URL to custom image to start in either `http://` or `file://` format",
+                                   "url");
+    parser->addOptions({cpusOption, diskOption, memOption, nameOption, cloudInitOption, imageOption});
 
     auto status = parser->commandParse(this);
 
@@ -145,6 +147,12 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
 
     if (!parser->positionalArguments().isEmpty())
     {
+        if (parser->isSet(imageOption))
+        {
+            cerr << "Cannot specify `--image` option and remote image at the same time\n";
+            return ParseCode::CommandLineError;
+        }
+
         auto remote_image_name = parser->positionalArguments().first();
         auto colon_count = remote_image_name.count(':');
 
@@ -196,6 +204,19 @@ mp::ParseCode cmd::Launch::parse_args(mp::ArgParser* parser)
             cerr << "error loading cloud-init config: " << e.what() << "\n";
             return ParseCode::CommandLineError;
         }
+    }
+
+    if (parser->isSet(imageOption))
+    {
+        auto image_url = parser->value(imageOption);
+
+        if (!image_url.startsWith("http") && !image_url.startsWith("file://"))
+        {
+            cerr << "Custom image URL needs to be in `http://` or `file://` format.\n";
+            return ParseCode::CommandLineError;
+        }
+
+        request.set_custom_image_path(parser->value(imageOption).toStdString());
     }
 
     return status;

--- a/src/client/cmd/shell.cpp
+++ b/src/client/cmd/shell.cpp
@@ -44,11 +44,12 @@ mp::ReturnCode cmd::Shell::run(mp::ArgParser* parser)
         auto ssh_info = reply.ssh_info().begin()->second;
         auto host = ssh_info.host();
         auto port = ssh_info.port();
+        auto username = ssh_info.username();
         auto priv_key_blob = ssh_info.priv_key_base64();
 
         try
         {
-            mp::SSHClient ssh_client{host, port, priv_key_blob};
+            mp::SSHClient ssh_client{host, port, username, priv_key_blob};
             ssh_client.connect();
         }
         catch (const std::exception& e)

--- a/src/client/formatter/table_formatter.cpp
+++ b/src/client/formatter/table_formatter.cpp
@@ -70,7 +70,8 @@ std::string mp::TableFormatter::format(const InfoReply& reply) const
         if (info.id().empty())
             out.write("{}\n", "Not Available");
         else
-            out.write("{} (Ubuntu {})\n", info.id().substr(0, 12), info.image_release());
+            out.write("{}{}\n", info.id().substr(0, 12),
+                      !info.image_release().empty() ? fmt::format(" (Ubuntu {})", info.image_release()) : "");
         out.write("{:<16}{}\n", "Load:", info.load().empty() ? "--" : info.load());
         out.write("{:<16}{}\n", "Disk usage:", to_usage(info.disk_usage(), info.disk_total()));
         out.write("{:<16}{}\n", "Memory usage:", to_usage(info.memory_usage(), info.memory_total()));
@@ -107,7 +108,8 @@ std::string mp::TableFormatter::format(const ListReply& reply) const
         out.write("{:<24}{:<12}{:<17}{:<}\n", instance.name(),
                   mp::format::status_string_for(instance.instance_status()),
                   instance.ipv4().empty() ? "--" : instance.ipv4(),
-                  instance.current_release().empty() ? "Not Available" : instance.current_release());
+                  instance.current_release().empty() ? "Not Available"
+                                                     : fmt::format("Ubuntu {}", instance.current_release()));
     }
 
     return out.str();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -81,13 +81,15 @@ mp::Query query_from(const mp::LaunchRequest* request, const std::string& name)
     return {name, image, false, request->remote_name(), query_type};
 }
 
-auto make_cloud_init_vendor_config(const mp::SSHKeyProvider& key_provider, const std::string& time_zone)
+auto make_cloud_init_vendor_config(const mp::SSHKeyProvider& key_provider, const std::string& time_zone,
+                                   const std::string& username)
 {
     auto ssh_key_line = fmt::format("ssh-rsa {} multipass@localhost", key_provider.public_key_as_base64());
 
     auto config = YAML::Load(mp::base_cloud_init_config);
     config["ssh_authorized_keys"].push_back(ssh_key_line);
     config["timezone"] = time_zone;
+    config["system_info"]["default_user"]["name"] = username;
 
     return config;
 }
@@ -146,9 +148,10 @@ void prepare_user_data(YAML::Node& user_data_config, YAML::Node& vendor_config)
 }
 
 mp::VirtualMachineDescription to_machine_desc(const mp::LaunchRequest* request, const std::string& name,
-                                              const std::string& mac_addr, const mp::VMImage& image,
-                                              YAML::Node& meta_data_config, YAML::Node& user_data_config,
-                                              YAML::Node& vendor_data_config, const mp::SSHKeyProvider& key_provider)
+                                              const std::string& mac_addr, const std::string& ssh_username,
+                                              const mp::VMImage& image, YAML::Node& meta_data_config,
+                                              YAML::Node& user_data_config, YAML::Node& vendor_data_config,
+                                              const mp::SSHKeyProvider& key_provider)
 {
     const auto num_cores = request->num_cores() < 1 ? 1 : request->num_cores();
     const auto mem_size = request->mem_size().empty() ? "1G" : request->mem_size();
@@ -156,7 +159,7 @@ mp::VirtualMachineDescription to_machine_desc(const mp::LaunchRequest* request, 
     const auto instance_dir = mp::utils::base_dir(image.image_path);
     const auto cloud_init_iso =
         make_cloud_init_image(name, instance_dir, meta_data_config, user_data_config, vendor_data_config);
-    return {num_cores, mem_size, disk_size, name, mac_addr, image, cloud_init_iso, key_provider};
+    return {num_cores, mem_size, disk_size, name, mac_addr, ssh_username, image, cloud_init_iso, key_provider};
 }
 
 template <typename T>
@@ -215,6 +218,10 @@ std::unordered_map<std::string, mp::VMSpecs> load_db(const mp::Path& data_path, 
         auto mem_size = record["mem_size"].toString();
         auto disk_space = record["disk_space"].toString();
         auto mac_addr = record["mac_addr"].toString();
+        auto ssh_username = record["ssh_username"].toString();
+
+        if (ssh_username.isEmpty())
+            ssh_username = "ubuntu";
 
         std::unordered_map<std::string, mp::VMMount> mounts;
         std::unordered_map<int, int> uid_map;
@@ -239,8 +246,12 @@ std::unordered_map<std::string, mp::VMSpecs> load_db(const mp::Path& data_path, 
             mounts[target_path] = mount;
         }
 
-        reconstructed_records[key] = {num_cores, mem_size.toStdString(), disk_space.toStdString(),
-                                      mac_addr.toStdString(), mounts};
+        reconstructed_records[key] = {num_cores,
+                                      mem_size.toStdString(),
+                                      disk_space.toStdString(),
+                                      mac_addr.toStdString(),
+                                      ssh_username.toStdString(),
+                                      mounts};
     }
     return reconstructed_records;
 }
@@ -348,7 +359,8 @@ mp::Daemon::Daemon(std::unique_ptr<const DaemonConfig> the_config)
         auto vm_image = fetch_image_for(name, config->factory->fetch_type(), *config->vault);
         const auto instance_dir = mp::utils::base_dir(vm_image.image_path);
         const auto cloud_init_iso = instance_dir.filePath("cloud-init-config.iso");
-        mp::VirtualMachineDescription vm_desc{spec.num_cores, spec.mem_size,  spec.disk_space,          name, mac_addr,
+        mp::VirtualMachineDescription vm_desc{spec.num_cores, spec.mem_size,  spec.disk_space,
+                                              name,           mac_addr,       spec.ssh_username,
                                               vm_image,       cloud_init_iso, *config->ssh_key_provider};
 
         try
@@ -458,7 +470,8 @@ try // clang-format on
 
     reply.set_create_message("Configuring " + name);
     server->Write(reply);
-    auto vendor_data_cloud_init_config = make_cloud_init_vendor_config(*config->ssh_key_provider, request->time_zone());
+    auto vendor_data_cloud_init_config =
+        make_cloud_init_vendor_config(*config->ssh_key_provider, request->time_zone(), config->ssh_username);
     auto meta_data_cloud_init_config = make_cloud_init_meta_config(name);
     auto user_data_cloud_init_config = YAML::Load(request->cloud_init_user_data());
     prepare_user_data(user_data_cloud_init_config, vendor_data_cloud_init_config);
@@ -477,13 +490,14 @@ try // clang-format on
         }
     }
     auto vm_desc =
-        to_machine_desc(request, name, mac_addr, vm_image, meta_data_cloud_init_config, user_data_cloud_init_config,
-                        vendor_data_cloud_init_config, *config->ssh_key_provider);
+        to_machine_desc(request, name, mac_addr, config->ssh_username, vm_image, meta_data_cloud_init_config,
+                        user_data_cloud_init_config, vendor_data_cloud_init_config, *config->ssh_key_provider);
 
     config->factory->prepare_instance_image(vm_image, vm_desc);
 
     vm_instances[name] = config->factory->create_virtual_machine(vm_desc, *this);
-    vm_instance_specs[name] = {vm_desc.num_cores, vm_desc.mem_size, vm_desc.disk_space, vm_desc.mac_addr, {}};
+    vm_instance_specs[name] = {vm_desc.num_cores, vm_desc.mem_size,     vm_desc.disk_space,
+                               vm_desc.mac_addr,  config->ssh_username, {}};
     persist_instances();
 
     reply.set_create_message("Starting " + name);
@@ -715,7 +729,8 @@ try // clang-format on
 
         if (vm->current_state() == mp::VirtualMachine::State::running)
         {
-            mp::SSHSession session{vm->ssh_hostname(), vm->ssh_port(), *config->ssh_key_provider};
+            mp::SSHSession session{vm->ssh_hostname(), vm->ssh_port(), vm_specs.ssh_username,
+                                   *config->ssh_key_provider};
 
             auto run_in_vm = [&session](const std::string& cmd) {
                 auto proc = session.exec(cmd);
@@ -985,6 +1000,7 @@ try // clang-format on
         ssh_info.set_host(it->second->ssh_hostname());
         ssh_info.set_port(it->second->ssh_port());
         ssh_info.set_priv_key_base64(config->ssh_key_provider->private_key_as_base64());
+        ssh_info.set_username(it->second->ssh_username());
         (*response->mutable_ssh_info())[name] = ssh_info;
     }
 
@@ -1340,6 +1356,7 @@ void mp::Daemon::persist_instances()
         json.insert("mem_size", QString::fromStdString(specs.mem_size));
         json.insert("disk_space", QString::fromStdString(specs.disk_space));
         json.insert("mac_addr", QString::fromStdString(specs.mac_addr));
+        json.insert("ssh_username", QString::fromStdString(specs.ssh_username));
 
         QJsonArray mounts;
         for (const auto& mount : specs.mounts)
@@ -1393,7 +1410,7 @@ void mp::Daemon::start_mount(const VirtualMachine::UPtr& vm, const std::string& 
 {
     auto& key_provider = *config->ssh_key_provider;
 
-    SSHSession session{vm->ssh_hostname(), vm->ssh_port(), key_provider};
+    SSHSession session{vm->ssh_hostname(), vm->ssh_port(), vm->ssh_username(), key_provider};
 
     auto sshfs_mount = std::make_unique<mp::SshfsMount>(std::move(session), source_path, target_path, gid_map, uid_map);
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -46,6 +46,7 @@ struct VMSpecs
     std::string mem_size;
     std::string disk_space;
     std::string mac_addr;
+    std::string ssh_username;
     std::unordered_map<std::string, VMMount> mounts;
 };
 

--- a/src/daemon/daemon_config.cpp
+++ b/src/daemon/daemon_config.cpp
@@ -63,9 +63,11 @@ std::unique_ptr<const mp::DaemonConfig> mp::DaemonConfigBuilder::build()
         server_address = platform::default_server_address();
     if (ssh_key_provider == nullptr)
         ssh_key_provider = std::make_unique<OpenSSHKeyProvider>(data_directory, cache_directory);
+    if (ssh_username.empty())
+        ssh_username = "multipass";
 
     return std::unique_ptr<const DaemonConfig>(
         new DaemonConfig{std::move(url_downloader), std::move(factory), std::move(image_host), std::move(vault),
                          std::move(name_generator), std::move(ssh_key_provider), std::move(logger), cache_directory,
-                         data_directory, server_address});
+                         data_directory, server_address, ssh_username});
 }

--- a/src/daemon/daemon_config.h
+++ b/src/daemon/daemon_config.h
@@ -48,6 +48,7 @@ struct DaemonConfig
     const multipass::Path cache_directory;
     const multipass::Path data_directory;
     const std::string server_address;
+    const std::string ssh_username;
 };
 
 struct DaemonConfigBuilder
@@ -62,6 +63,7 @@ struct DaemonConfigBuilder
     multipass::Path cache_directory;
     multipass::Path data_directory;
     std::string server_address;
+    std::string ssh_username;
     multipass::days days_to_expire{14};
 
     std::unique_ptr<const DaemonConfig> build();

--- a/src/daemon/ubuntu_image_host.cpp
+++ b/src/daemon/ubuntu_image_host.cpp
@@ -23,6 +23,7 @@
 #include <multipass/simple_streams_index.h>
 #include <multipass/url_downloader.h>
 
+#include <QTimer>
 #include <QUrl>
 
 #include <algorithm>
@@ -70,6 +71,7 @@ mp::UbuntuVMImageHost::UbuntuVMImageHost(std::unordered_map<std::string, std::st
                                          URLDownloader* downloader, std::chrono::seconds manifest_time_to_live)
     : manifest_time_to_live{manifest_time_to_live}, url_downloader{downloader}, remotes{remotes}
 {
+    QTimer::singleShot(0, [this]() { update_manifest(); });
 }
 
 mp::VMImageInfo mp::UbuntuVMImageHost::info_for(const Query& query)

--- a/src/network/url_downloader.cpp
+++ b/src/network/url_downloader.cpp
@@ -89,12 +89,15 @@ void mp::URLDownloader::download_to(const QUrl& url, const QString& file_name, i
 
     auto progress_monitor = [&file, &monitor, download_type, size](QNetworkReply* reply, QTimer& download_timeout,
                                                                    qint64 bytes_received, qint64 bytes_total) {
+        if (bytes_received == 0)
+            return;
+
         if (download_timeout.isActive())
             download_timeout.stop();
         else
             return;
 
-        if (bytes_total == -1)
+        if (bytes_total == -1 && size > 0)
             bytes_total = size;
         auto progress = (size < 0) ? size : (100 * bytes_received + bytes_total / 2) / bytes_total;
         if (file.write(reply->readAll()) < 0)

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.cpp
@@ -241,6 +241,7 @@ mp::LibVirtVirtualMachine::LibVirtVirtualMachine(const mp::VirtualMachineDescrip
       connection{connection},
       domain{get_domain_definition(connection, desc, bridge_name)},
       mac_addr{get_instance_mac_addr(domain.get())},
+      username{desc.ssh_username},
       ip{get_instance_ip(connection, mac_addr)},
       monitor{&monitor}
 {
@@ -303,6 +304,11 @@ std::string mp::LibVirtVirtualMachine::ssh_hostname()
     mp::utils::try_action_for(on_timeout, std::chrono::minutes(2), action);
 
     return ip.value().as_string();
+}
+
+std::string mp::LibVirtVirtualMachine::ssh_username()
+{
+    return username;
 }
 
 std::string mp::LibVirtVirtualMachine::ipv4()

--- a/src/platform/backends/libvirt/libvirt_virtual_machine.h
+++ b/src/platform/backends/libvirt/libvirt_virtual_machine.h
@@ -45,6 +45,7 @@ public:
     State current_state() override;
     int ssh_port() override;
     std::string ssh_hostname() override;
+    std::string ssh_username() override;
     std::string ipv4() override;
     std::string ipv6() override;
     void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
@@ -54,6 +55,7 @@ private:
     virConnectPtr connection;
     DomainUPtr domain;
     const std::string mac_addr;
+    const std::string username;
     optional<IPAddress> ip;
     VMStatusMonitor* monitor;
 };

--- a/src/platform/backends/qemu/qemu_virtual_machine.cpp
+++ b/src/platform/backends/qemu/qemu_virtual_machine.cpp
@@ -135,6 +135,7 @@ mp::QemuVirtualMachine::QemuVirtualMachine(const VirtualMachineDescription& desc
       is_legacy_ip{ip ? true : false},
       tap_device_name{tap_device_name},
       mac_addr{desc.mac_addr},
+      username{desc.ssh_username},
       dnsmasq_server{&dnsmasq_server},
       monitor{&monitor},
       vm_process{make_qemu_process(desc, tap_device_name, mac_addr)}
@@ -291,6 +292,11 @@ std::string mp::QemuVirtualMachine::ssh_hostname()
     }
 
     return ip.value().as_string();
+}
+
+std::string mp::QemuVirtualMachine::ssh_username()
+{
+    return username;
 }
 
 std::string mp::QemuVirtualMachine::ipv4()

--- a/src/platform/backends/qemu/qemu_virtual_machine.h
+++ b/src/platform/backends/qemu/qemu_virtual_machine.h
@@ -47,6 +47,7 @@ public:
     State current_state() override;
     int ssh_port() override;
     std::string ssh_hostname() override;
+    std::string ssh_username() override;
     std::string ipv4() override;
     std::string ipv6() override;
     void wait_until_ssh_up(std::chrono::milliseconds timeout) override;
@@ -62,6 +63,7 @@ private:
     bool is_legacy_ip;
     const std::string tap_device_name;
     const std::string mac_addr;
+    const std::string username;
     DNSMasqServer* dnsmasq_server;
     VMStatusMonitor* monitor;
     std::unique_ptr<QProcess> vm_process;

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -215,6 +215,7 @@ message SSHInfo {
     int32 port = 1;
     string priv_key_base64 = 2;
     string host = 3;
+    string username = 4;
 }
 
 message SSHInfoReply {

--- a/src/rpc/multipass.proto
+++ b/src/rpc/multipass.proto
@@ -44,6 +44,7 @@ message LaunchRequest {
     string time_zone = 7;
     string cloud_init_user_data = 8;
     string remote_name = 9;
+    string custom_image_path = 10;
 }
 
 message LaunchError {

--- a/src/ssh/scp_client.cpp
+++ b/src/ssh/scp_client.cpp
@@ -40,8 +40,9 @@ SCPUPtr make_scp_session(ssh_session session, int mode, const char* path)
 }
 }
 
-mp::SCPClient::SCPClient(const std::string& host, int port, const std::string& priv_key_blob)
-    : SCPClient{std::make_unique<mp::SSHSession>(host, port, mp::SSHClientKeyProvider(priv_key_blob))}
+mp::SCPClient::SCPClient(const std::string& host, int port, const std::string& username,
+                         const std::string& priv_key_blob)
+    : SCPClient{std::make_unique<mp::SSHSession>(host, port, username, mp::SSHClientKeyProvider(priv_key_blob))}
 {
 }
 

--- a/src/ssh/ssh_client.cpp
+++ b/src/ssh/ssh_client.cpp
@@ -35,8 +35,9 @@ mp::SSHClient::ChannelUPtr make_channel(ssh_session session)
 }
 }
 
-mp::SSHClient::SSHClient(const std::string& host, int port, const std::string& priv_key_blob)
-    : SSHClient{std::make_unique<mp::SSHSession>(host, port, mp::SSHClientKeyProvider(priv_key_blob))}
+mp::SSHClient::SSHClient(const std::string& host, int port, const std::string& username,
+                         const std::string& priv_key_blob)
+    : SSHClient{std::make_unique<mp::SSHSession>(host, port, username, mp::SSHClientKeyProvider(priv_key_blob))}
 {
 }
 

--- a/src/ssh/ssh_session.cpp
+++ b/src/ssh/ssh_session.cpp
@@ -87,7 +87,8 @@ auto initialize_session()
 }
 }
 
-mp::SSHSession::SSHSession(const std::string& host, int port, const SSHKeyProvider* key_provider)
+mp::SSHSession::SSHSession(const std::string& host, int port, const std::string& username,
+                           const SSHKeyProvider* key_provider)
     : session{initialize_session(), ssh_free}
 {
     if (session == nullptr)
@@ -98,7 +99,7 @@ mp::SSHSession::SSHSession(const std::string& host, int port, const SSHKeyProvid
 
     SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_HOST, host.c_str());
     SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_PORT, &port);
-    SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_USER, "ubuntu");
+    SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_USER, username.c_str());
     SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_TIMEOUT, &timeout);
     SSH::throw_on_error(ssh_options_set, session, SSH_OPTIONS_NODELAY, &nodelay);
     SSH::throw_on_error(ssh_connect, session);
@@ -106,12 +107,13 @@ mp::SSHSession::SSHSession(const std::string& host, int port, const SSHKeyProvid
         SSH::throw_on_error(ssh_userauth_publickey, session, nullptr, key_provider->private_key());
 }
 
-mp::SSHSession::SSHSession(const std::string& host, int port, const SSHKeyProvider& key_provider)
-    : SSHSession(host, port, &key_provider)
+mp::SSHSession::SSHSession(const std::string& host, int port, const std::string& username,
+                           const SSHKeyProvider& key_provider)
+    : SSHSession(host, port, username, &key_provider)
 {
 }
 
-mp::SSHSession::SSHSession(const std::string& host, int port) : SSHSession(host, port, nullptr)
+mp::SSHSession::SSHSession(const std::string& host, int port) : SSHSession(host, port, "ubuntu", nullptr)
 {
 }
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -163,11 +163,11 @@ void mp::utils::wait_for_cloud_init(mp::VirtualMachine* virtual_machine, std::ch
 {
     auto action = [virtual_machine, &process_vm_events] {
         process_vm_events();
-        mp::SSHSession session{virtual_machine->ssh_hostname(), virtual_machine->ssh_port(),
-                               virtual_machine->key_provider};
-        auto ssh_process = session.exec({"[ -e /var/lib/cloud/instance/boot-finished ]"});
         try
         {
+            mp::SSHSession session{virtual_machine->ssh_hostname(), virtual_machine->ssh_port(),
+                                   virtual_machine->ssh_username(), virtual_machine->key_provider};
+            auto ssh_process = session.exec({"[ -e /var/lib/cloud/instance/boot-finished ]"});
             return ssh_process.exit_code() == 0 ? mp::utils::TimeoutAction::done : mp::utils::TimeoutAction::retry;
         }
         catch (const std::exception& e)

--- a/tests/stub_virtual_machine.h
+++ b/tests/stub_virtual_machine.h
@@ -61,6 +61,11 @@ struct StubVirtualMachine final : public multipass::VirtualMachine
         return "localhost";
     }
 
+    std::string ssh_username() override
+    {
+        return "ubuntu";
+    }
+
     std::string ipv4() override
     {
         return {};

--- a/tests/stub_vm_image_vault.h
+++ b/tests/stub_vm_image_vault.h
@@ -32,7 +32,7 @@ struct StubVMImageVault final : public multipass::VMImageVault
     multipass::VMImage fetch_image(const multipass::FetchType&, const multipass::Query&, const PrepareAction& prepare,
                                    const multipass::ProgressMonitor&) override
     {
-        return prepare({dummy_image.name(), dummy_image.name(), dummy_image.name(), {}, {}});
+        return prepare({dummy_image.name(), dummy_image.name(), dummy_image.name(), {}, {}, {}, {}});
     };
 
     void remove(const std::string&) override{};

--- a/tests/test_cli_client.cpp
+++ b/tests/test_cli_client.cpp
@@ -141,55 +141,80 @@ TEST_F(Client, shell_cmd_help_ok)
     EXPECT_THAT(send_command({"shell", "-h"}), Eq(mp::ReturnCode::Ok));
 }
 
-// create cli tests
-TEST_F(Client, create_cmd_good_arguments)
+// launch cli tests
+TEST_F(Client, launch_cmd_good_arguments)
 {
     EXPECT_THAT(send_command({"launch", "foo"}), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, create_cmd_help_ok)
+TEST_F(Client, launch_cmd_help_ok)
 {
     EXPECT_THAT(send_command({"launch", "-h"}), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, create_cmd_fails_multiple_args)
+TEST_F(Client, launch_cmd_fails_multiple_args)
 {
     EXPECT_THAT(send_command({"launch", "foo", "bar"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
-TEST_F(Client, create_cmd_unknown_option_fails)
+TEST_F(Client, launch_cmd_unknown_option_fails)
 {
     EXPECT_THAT(send_command({"launch", "-z", "2"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
-TEST_F(Client, create_cmd_name_option_ok)
+TEST_F(Client, launch_cmd_name_option_ok)
 {
     EXPECT_THAT(send_command({"launch", "-n", "foo"}), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, create_cmd_name_option_fails_no_value)
+TEST_F(Client, launch_cmd_name_option_fails_no_value)
 {
     EXPECT_THAT(send_command({"launch", "-n"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
-TEST_F(Client, create_cmd_memory_option_ok)
+TEST_F(Client, launch_cmd_memory_option_ok)
 {
     EXPECT_THAT(send_command({"launch", "-m", "1G"}), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, create_cmd_memory_option_fails_no_value)
+TEST_F(Client, launch_cmd_memory_option_fails_no_value)
 {
     EXPECT_THAT(send_command({"launch", "-m"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
-TEST_F(Client, create_cmd_cpu_option_ok)
+TEST_F(Client, launch_cmd_cpu_option_ok)
 {
     EXPECT_THAT(send_command({"launch", "-c", "2"}), Eq(mp::ReturnCode::Ok));
 }
 
-TEST_F(Client, create_cmd_cpu_option_fails_no_value)
+TEST_F(Client, launch_cmd_cpu_option_fails_no_value)
 {
     EXPECT_THAT(send_command({"launch", "-c"}), Eq(mp::ReturnCode::CommandLineError));
+}
+
+TEST_F(Client, launch_cmd_image_option_file_ok)
+{
+    EXPECT_THAT(send_command({"launch", "--image", "file://foo"}), Eq(mp::ReturnCode::Ok));
+}
+
+TEST_F(Client, launch_cmd_image_option_http_ok)
+{
+    EXPECT_THAT(send_command({"launch", "--image", "http://foo"}), Eq(mp::ReturnCode::Ok));
+}
+
+TEST_F(Client, launch_cmd_image_option_invalid_prefix_fail)
+{
+    EXPECT_THAT(send_command({"launch", "--image", "image://foo"}), Eq(mp::ReturnCode::CommandLineError));
+}
+
+TEST_F(Client, launch_cmd_image_option_no_prefix_fail)
+{
+    EXPECT_THAT(send_command({"launch", "--image", "foo"}), Eq(mp::ReturnCode::CommandLineError));
+}
+
+TEST_F(Client, launch_cmd_image_option_and_image_pos_arg_fail)
+{
+    EXPECT_THAT(send_command({"launch", "--image", "file://foo", "bar"}), Eq(mp::ReturnCode::CommandLineError));
 }
 
 // purge cli tests

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -273,7 +273,7 @@ TEST_F(ImageVault, uses_image_from_prepare)
     }
 
     auto prepare = [&file_name](const mp::VMImage& source_image) -> mp::VMImage {
-        return {file_name, "", "", source_image.id, {}};
+        return {file_name, "", "", source_image.id, "", "", {}};
     };
 
     mp::DefaultVMImageVault vault{&host, &url_downloader, cache_dir.path(), data_dir.path(), mp::days{0}};
@@ -300,7 +300,7 @@ TEST_F(ImageVault, image_purged_expired)
             file.write("");
             file.flush();
         }
-        return {file_name, "", "", source_image.id, {}};
+        return {file_name, "", "", source_image.id, "", "", {}};
     };
     auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly, default_query, prepare, stub_monitor);
 
@@ -327,7 +327,7 @@ TEST_F(ImageVault, image_exists_not_expired)
             file.write("");
             file.flush();
         }
-        return {file_name, "", "", source_image.id, {}};
+        return {file_name, "", "", source_image.id, "", "", {}};
     };
     auto vm_image = vault.fetch_image(mp::FetchType::ImageOnly, default_query, prepare, stub_monitor);
 

--- a/tests/test_image_vault.cpp
+++ b/tests/test_image_vault.cpp
@@ -106,7 +106,7 @@ struct ImageVault : public testing::Test
     QTemporaryDir cache_dir;
     QTemporaryDir data_dir;
     std::string instance_name{"valley-pied-piper"};
-    mp::Query default_query{instance_name, "xenial", false, ""};
+    mp::Query default_query{instance_name, "xenial", false, "", mp::Query::Type::SimpleStreams};
 };
 }
 

--- a/tests/test_output_formatter.cpp
+++ b/tests/test_output_formatter.cpp
@@ -37,7 +37,7 @@ auto construct_single_instance_list_reply()
     auto list_entry = list_reply.add_instances();
     list_entry->set_name("foo");
     list_entry->mutable_instance_status()->set_status(mp::InstanceStatus::RUNNING);
-    list_entry->set_current_release("Ubuntu 16.04 LTS");
+    list_entry->set_current_release("16.04 LTS");
     list_entry->set_ipv4("10.168.32.2");
 
     return list_reply;
@@ -50,13 +50,13 @@ auto construct_multiple_instances_list_reply()
     auto list_entry = list_reply.add_instances();
     list_entry->set_name("bogus-instance");
     list_entry->mutable_instance_status()->set_status(mp::InstanceStatus::RUNNING);
-    list_entry->set_current_release("Ubuntu 16.04 LTS");
+    list_entry->set_current_release("16.04 LTS");
     list_entry->set_ipv4("10.21.124.56");
 
     list_entry = list_reply.add_instances();
     list_entry->set_name("bombastic");
     list_entry->mutable_instance_status()->set_status(mp::InstanceStatus::STOPPED);
-    list_entry->set_current_release("Ubuntu 18.04 LTS");
+    list_entry->set_current_release("18.04 LTS");
 
     return list_reply;
 }
@@ -273,7 +273,7 @@ TEST_F(JsonFormatter, single_instance_list_output)
                                 "                \"10.168.32.2\"\n"
                                 "            ],\n"
                                 "            \"name\": \"foo\",\n"
-                                "            \"release\": \"Ubuntu 16.04 LTS\",\n"
+                                "            \"release\": \"16.04 LTS\",\n"
                                 "            \"state\": \"RUNNING\"\n"
                                 "        }\n"
                                 "    ]\n"
@@ -296,14 +296,14 @@ TEST_F(JsonFormatter, multiple_instances_list_output)
                                 "                \"10.21.124.56\"\n"
                                 "            ],\n"
                                 "            \"name\": \"bogus-instance\",\n"
-                                "            \"release\": \"Ubuntu 16.04 LTS\",\n"
+                                "            \"release\": \"16.04 LTS\",\n"
                                 "            \"state\": \"RUNNING\"\n"
                                 "        },\n"
                                 "        {\n"
                                 "            \"ipv4\": [\n"
                                 "            ],\n"
                                 "            \"name\": \"bombastic\",\n"
-                                "            \"release\": \"Ubuntu 18.04 LTS\",\n"
+                                "            \"release\": \"18.04 LTS\",\n"
                                 "            \"state\": \"STOPPED\"\n"
                                 "        }\n"
                                 "    ]\n"
@@ -479,7 +479,7 @@ TEST_F(CSVFormatter, single_instance_list_output)
     auto list_reply = construct_single_instance_list_reply();
 
     auto expected_output = "Name,State,IPv4,IPv6,Release\n"
-                           "foo,RUNNING,10.168.32.2,,Ubuntu 16.04 LTS\n";
+                           "foo,RUNNING,10.168.32.2,,16.04 LTS\n";
 
     mp::CSVFormatter csv_formatter;
     auto output = csv_formatter.format(list_reply);
@@ -492,8 +492,8 @@ TEST_F(CSVFormatter, multiple_instance_list_output)
     auto list_reply = construct_multiple_instances_list_reply();
 
     auto expected_output = "Name,State,IPv4,IPv6,Release\n"
-                           "bogus-instance,RUNNING,10.21.124.56,,Ubuntu 16.04 LTS\n"
-                           "bombastic,STOPPED,,,Ubuntu 18.04 LTS\n";
+                           "bogus-instance,RUNNING,10.21.124.56,,16.04 LTS\n"
+                           "bombastic,STOPPED,,,18.04 LTS\n";
 
     mp::CSVFormatter csv_formatter;
     auto output = csv_formatter.format(list_reply);
@@ -567,7 +567,7 @@ TEST_F(YamlFormatter, single_instance_list_output)
                            "  - state: RUNNING\n"
                            "    ipv4:\n"
                            "      - 10.168.32.2\n"
-                           "    release: Ubuntu 16.04 LTS\n";
+                           "    release: 16.04 LTS\n";
 
     mp::YamlFormatter formatter;
     auto output = formatter.format(list_reply);
@@ -583,12 +583,12 @@ TEST_F(YamlFormatter, multiple_instance_list_output)
                            "  - state: RUNNING\n"
                            "    ipv4:\n"
                            "      - 10.21.124.56\n"
-                           "    release: Ubuntu 16.04 LTS\n"
+                           "    release: 16.04 LTS\n"
                            "bombastic:\n"
                            "  - state: STOPPED\n"
                            "    ipv4:\n"
                            "      - \"\"\n"
-                           "    release: Ubuntu 18.04 LTS\n";
+                           "    release: 18.04 LTS\n";
 
     mp::YamlFormatter formatter;
     auto output = formatter.format(list_reply);

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -77,6 +77,7 @@ struct QemuBackend : public testing::Test
                                                       "",
                                                       "pied-piper-valley",
                                                       "",
+                                                      "",
                                                       {dummy_image.name(), "", "", "", "", "", {}},
                                                       dummy_cloud_init_iso.name(),
                                                       key_provider};

--- a/tests/test_qemu_backend.cpp
+++ b/tests/test_qemu_backend.cpp
@@ -77,7 +77,7 @@ struct QemuBackend : public testing::Test
                                                       "",
                                                       "pied-piper-valley",
                                                       "",
-                                                      {dummy_image.name(), "", "", "", {}},
+                                                      {dummy_image.name(), "", "", "", "", "", {}},
                                                       dummy_cloud_init_iso.name(),
                                                       key_provider};
     QTemporaryDir data_dir;

--- a/tests/test_ssh_session.cpp
+++ b/tests/test_ssh_session.cpp
@@ -48,7 +48,7 @@ TEST(SSHSession, throws_when_unable_to_auth)
     mp::test::StubSSHKeyProvider key_provider;
     REPLACE(ssh_connect, [](auto...) { return SSH_OK; });
     REPLACE(ssh_userauth_publickey, [](auto...) { return SSH_AUTH_ERROR; });
-    EXPECT_THROW(mp::SSHSession("theanswertoeverything", 42, key_provider), std::runtime_error);
+    EXPECT_THROW(mp::SSHSession("theanswertoeverything", 42, "ubuntu", key_provider), std::runtime_error);
 }
 
 TEST(SSHSession, exec_throws_on_a_dead_session)

--- a/tests/test_ubuntu_image_host.cpp
+++ b/tests/test_ubuntu_image_host.cpp
@@ -41,7 +41,7 @@ struct UbuntuImageHost : public testing::Test
 {
     mp::Query make_query(std::string release, std::string remote)
     {
-        return {"", release, false, remote};
+        return {"", release, false, remote, mp::Query::Type::SimpleStreams};
     }
 
     QString host_url{QUrl::fromLocalFile(mpt::test_data_path()).toString() + "releases/"};


### PR DESCRIPTION
Already existing instances will use the `ubuntu` ssh username, but newly launched
instances will use `multipass` for the username.

Fixes #250